### PR TITLE
fix: update go version in mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,4 +136,4 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 )
 
-go 1.23
+go 1.23.0


### PR DESCRIPTION
Update go version reference from 1.23 to 1.23.0

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
Updates go version reference in `go.mod` to 1.23.0. The current go reference is invalid (1.23) causing an error when attempting to build the lifecycle component.

[Documentation](https://buildpacks.io/docs/for-platform-operators/tutorials/lifecycle/) instructs users to make the lifecycle package (eg: `make build-darwin-amd64`). This instruction fails when attempting to download the referenced version of go with a message like:

```
go: downloading go1.23 (darwin/amd64)
go: download go1.23 for darwin/amd64: toolchain not available
make: *** [build-darwin-amd64-lifecycle] Error 1
```


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Fixes make errors based on invalid go version reference in go.mod file. Updates go version reference to 1.23.0.

---

